### PR TITLE
Add workflow preventing unwated PR to original repo

### DIFF
--- a/.github/.workflows/preventPR.yml
+++ b/.github/.workflows/preventPR.yml
@@ -1,0 +1,23 @@
+name: Prevent Pull Requests to the Original Repo
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if the PR is trying to merge into the original repo
+        run: |
+          # Obtener el repositorio base (donde se quiere hacer la PR) y el repositorio de origen (de donde proviene la PR)
+          BASE_REPO="${{ github.event.pull_request.base.repo.full_name }}"
+          HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+
+          # Verificar si la PR está dirigida al repositorio original de los profesores
+          if [[ "$BASE_REPO" == "isa-group/ppinot-visual" && "$HEAD_REPO" == "tu-usuario/tu-fork" ]]; then
+            echo "Error: No puedes hacer PR hacia el repositorio original 'isa-group/ppinot-visual' desde tu fork."
+            exit 1
+          fi
+
+          echo "La Pull Request está dirigida a un repositorio permitido."


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added a GitHub Actions workflow to prevent unwanted PRs.

- Configured the workflow to trigger on PR events.

- Implemented a check to block PRs to the original repository.

- Provided error messaging for invalid PR attempts.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>preventPR.yml</strong><dd><code>Add workflow to prevent PRs to original repository</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/.workflows/preventPR.yml

<li>Added a new workflow file for PR validation.<br> <li> Configured triggers for PR events like opened and synchronized.<br> <li> Implemented a script to check PR target repository.<br> <li> Added error handling for invalid PR attempts.


</details>


  </td>
  <td><a href="https://github.com/luciaPG/VisualPPINOT/pull/8/files#diff-5748ebc2388fbfab7e83dfa9556dbc9303c15c8b00dfe4d62aa7320272e513e0">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>